### PR TITLE
Fix dark mode settings storage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ export default {
     },
   },
   created() {
-    this.$vuetify.theme.dark = localStorage.getItem("darkTheme") == "true";
+    this.$vuetify.theme.dark = localStorage.getItem("darkMode") == "true";
   },
   computed: {
     baseUrl() {


### PR DESCRIPTION
Before, dark mode settings would not be saved. Now, it is saved.